### PR TITLE
Fix native crash on MASoundPool.discard.

### DIFF
--- a/src/main/java/games/rednblack/miniaudio/MASoundPool.java
+++ b/src/main/java/games/rednblack/miniaudio/MASoundPool.java
@@ -47,7 +47,9 @@ public class MASoundPool extends Pool<MASound> {
 
     @Override
     protected void discard(MASound object) {
-        object.dispose();
+        // super.discard() resets the sound with native calls, so it must run before
+        // dispose() frees the ma_sound pointer (use-after-free crash otherwise).
         super.discard(object);
+        object.dispose();
     }
 }


### PR DESCRIPTION
`MASoundPool.discard()` no longer calls `super.discard(object)` after `object.dispose()`. 

The super call was the entire bug: libGDX's `Pool.discard()` runs `reset(object)`, and `MASound.reset()` calls `stop()`/`setVolume()`/`setPan()`/`setPitch()` - four native calls on the `ma_sound*` that `dispose()` had just freed via `ma_sound_uninit` + `ma_free`. 

Whether it segfaults depends on allocator behavior, which is why it shows up intermittently (happens in app shutdown, see stack trace). 

Also, resetting an object that's leaving the pool for good serves no purpose, so dropping the call loses nothing. I left a comment explaining why `super.discard()` must not come back.

Stack trace that triggered this PR (iOS RoboVM):

```
Crashed: com.apple.main-thread
0  gdx-miniaudio                  0x5aedc Java_games_rednblack_miniaudio_MiniAudio_jniStopSound + 16
1  IOSLauncher                    0x7d3394 Java_games_rednblack_miniaudio_MiniAudio_jniStopSound__J + 4382471060
2  IOSLauncher                    0x7d33b0 Java_games_rednblack_miniaudio_MiniAudio_jniStopSound + 4382471088
3  IOSLauncher                    0x7d32fc [J]games.rednblack.miniaudio.MiniAudio.jniStopSound(J)V + 4382470908
4  IOSLauncher                    0x7d32b4 [J]games.rednblack.miniaudio.MiniAudio.stopSound(J)V + 1589 (MiniAudio.java:1589)
5  IOSLauncher                    0x7ce790 [J]games.rednblack.miniaudio.MASound.stop()V + 65 (MASound.java:65)
6  IOSLauncher                    0x7cef94 [J]games.rednblack.miniaudio.MASound.reset()V + 399 (MASound.java:399)
7  IOSLauncher                    0x5d1d80 [J]com.badlogic.gdx.utils.Pool.reset(Ljava/lang/Object;)V + 85 (Pool.java:85)
8  IOSLauncher                    0x5d1dc4 [J]com.badlogic.gdx.utils.Pool.discard(Ljava/lang/Object;)V + 91 (Pool.java:91)
9  IOSLauncher                    0x7cf320 [J]games.rednblack.miniaudio.MASoundPool.discard(Lgames/rednblack/miniaudio/MASound;)V + 52 (MASoundPool.java:52)
10 IOSLauncher                    0x7cf364 [J]games.rednblack.miniaudio.MASoundPool.discard(Ljava/lang/Object;)V + 10 (MASoundPool.java:10)
11 IOSLauncher                    0x5d1fdc [J]com.badlogic.gdx.utils.Pool.clear()V + 117 (Pool.java:117)
12 IOSLauncher                    0x7db664 [J]games.rednblack.miniaudio.gdxaudio.GdxMASound.dispose()V + 97 (GdxMASound.java:97)
13 IOSLauncher                    0x3dc700 [J]com.badlogic.gdx.assets.AssetManager.unload(Ljava/lang/String;)V + 268 (AssetManager.java:268)
14 IOSLauncher                    0x3d9574 [j]com.badlogic.gdx.assets.AssetManager.unload(Ljava/lang/String;)V[synchronized] + 4378301812
15 IOSLauncher                    0x3df7fc [J]com.badlogic.gdx.assets.AssetManager.clear()V + 732 (AssetManager.java:732)
16 IOSLauncher                    0x3df45c [J]com.badlogic.gdx.assets.AssetManager.dispose()V + 703 (AssetManager.java:703)
17 IOSLauncher                    0x282e61c [J]viva.asset.AssetManager.dispose()V + 28 (AssetManager.java:28)
18 IOSLauncher                    0xaa7058 [J]mmorpg.main.Client.dispose()V + 246 (Client.java:246)
19 IOSLauncher                    0x3f40dc [J]com.badlogic.gdx.backends.iosrobovm.IOSApplication.willTerminate(Lorg/robovm/apple/uikit/UIApplication;)V + 284 (IOSApplication.java:284)
20 IOSLauncher                    0x3f59c8 [J]com.badlogic.gdx.backends.iosrobovm.IOSApplication$Delegate.willTerminate(Lorg/robovm/apple/uikit/UIApplication;)V + 84 (IOSApplication$Delegate.java:84)
21 IOSLauncher                    0x3f5b54 [J]com.badlogic.gdx.backends.iosrobovm.IOSApplication$Delegate.$cb$applicationWillTerminate$(Lcom/badlogic/gdx/backends/iosrobovm/IOSApplication$Delegate;Lorg/robovm/objc/Selector;Lorg/robovm/apple/uikit/UIApplication;)V + 4378418004
22 IOSLauncher                    0x3f5798 [j]com.badlogic.gdx.backends.iosrobovm.IOSApplication$Delegate.$cb$applicationWillTerminate$(Lcom/badlogic/gdx/backends/iosrobovm/IOSApplication$Delegate;Lorg/robovm/objc/Selector;Lorg/robovm/apple/uikit/UIApplication;)V[callback] + 4378417048
23 UIKitCore                      0xc844b8 -[UIApplication _terminateWithStatus:] + 192
```